### PR TITLE
Added loggs in cases when process dissappeared, updated README

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/intelsdi-x/snap-plugin-collector-processes",
-	"GoVersion": "go1.6",
-	"GodepVersion": "v62",
+	"GoVersion": "go1.5",
+	"GodepVersion": "v69",
 	"Deps": [
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",
@@ -10,75 +10,75 @@
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap-plugin-utilities/config",
-			"Rev": "04621af7a3979bcb8aaf08c3b6542b43fe0bf6cf"
+			"Rev": "0b327aae781a2e94b414be121d5ac4668750156c"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap-plugin-utilities/str",
-			"Rev": "04621af7a3979bcb8aaf08c3b6542b43fe0bf6cf"
+			"Rev": "0b327aae781a2e94b414be121d5ac4668750156c"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin",
-			"Comment": "v0.13.0-beta-131-g4d7d4ca",
-			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+			"Comment": "v0.15.0-beta-77-ge2f56bd",
+			"Rev": "e2f56bdb168dcbcc6b84e778cb9772e4ee0acb1e"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/cpolicy",
-			"Comment": "v0.13.0-beta-131-g4d7d4ca",
-			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+			"Comment": "v0.15.0-beta-77-ge2f56bd",
+			"Rev": "e2f56bdb168dcbcc6b84e778cb9772e4ee0acb1e"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/encoding",
-			"Comment": "v0.13.0-beta-131-g4d7d4ca",
-			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+			"Comment": "v0.15.0-beta-77-ge2f56bd",
+			"Rev": "e2f56bdb168dcbcc6b84e778cb9772e4ee0acb1e"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/encrypter",
-			"Comment": "v0.13.0-beta-131-g4d7d4ca",
-			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+			"Comment": "v0.15.0-beta-77-ge2f56bd",
+			"Rev": "e2f56bdb168dcbcc6b84e778cb9772e4ee0acb1e"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core",
-			"Comment": "v0.13.0-beta-131-g4d7d4ca",
-			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+			"Comment": "v0.15.0-beta-77-ge2f56bd",
+			"Rev": "e2f56bdb168dcbcc6b84e778cb9772e4ee0acb1e"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/cdata",
-			"Comment": "v0.13.0-beta-131-g4d7d4ca",
-			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+			"Comment": "v0.15.0-beta-77-ge2f56bd",
+			"Rev": "e2f56bdb168dcbcc6b84e778cb9772e4ee0acb1e"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/ctypes",
-			"Comment": "v0.13.0-beta-131-g4d7d4ca",
-			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+			"Comment": "v0.15.0-beta-77-ge2f56bd",
+			"Rev": "e2f56bdb168dcbcc6b84e778cb9772e4ee0acb1e"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core/serror",
-			"Comment": "v0.13.0-beta-131-g4d7d4ca",
-			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+			"Comment": "v0.15.0-beta-77-ge2f56bd",
+			"Rev": "e2f56bdb168dcbcc6b84e778cb9772e4ee0acb1e"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/ctree",
-			"Comment": "v0.13.0-beta-131-g4d7d4ca",
-			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+			"Comment": "v0.15.0-beta-77-ge2f56bd",
+			"Rev": "e2f56bdb168dcbcc6b84e778cb9772e4ee0acb1e"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/schedule",
-			"Comment": "v0.13.0-beta-131-g4d7d4ca",
-			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+			"Comment": "v0.15.0-beta-77-ge2f56bd",
+			"Rev": "e2f56bdb168dcbcc6b84e778cb9772e4ee0acb1e"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/scheduler/wmap",
-			"Comment": "v0.13.0-beta-131-g4d7d4ca",
-			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+			"Comment": "v0.15.0-beta-77-ge2f56bd",
+			"Rev": "e2f56bdb168dcbcc6b84e778cb9772e4ee0acb1e"
 		},
 		{
 			"ImportPath": "github.com/robfig/cron",
-			"Comment": "v1-16-g0f39cf7",
-			"Rev": "0f39cf7ebc65a602f45692f9894bd6a193faf8fa"
+			"Comment": "v1-7-g32d9c27",
+			"Rev": "32d9c273155a0506d27cf73dd1246e86a470997e"
 		},
 		{
 			"ImportPath": "golang.org/x/sys/unix",
-			"Rev": "c8bc69bc2db9c57ccf979550bc69655df5039a8a"
+			"Rev": "7f918dd405547ecb864d14a8ecbbfe205b5f930f"
 		},
 		{
 			"ImportPath": "gopkg.in/yaml.v2",

--- a/README.md
+++ b/README.md
@@ -70,16 +70,16 @@ Load snap-plugin-collector-processes plugin:
 ```
 $ $SNAP_PATH/bin/snapctl plugin load snap-plugin-collector-processes
 ```
-Load file plugin for publishing:
+Load mock-file plugin for publishing:
 ```
-$ $SNAP_PATH/bin/snapctl plugin load $SNAP_PATH/plugin/snap-publisher-file
+$ $SNAP_PATH/bin/snapctl plugin load $SNAP_PATH/plugin/snap-plugin-publisher-mock-file
 ```
 See available metrics for your system:
 ```
 $ $SNAP_PATH/bin/snapctl metric list
 ```
 
-Create a task manifest file to use snap-plugin-collector-processes plugin (exemplary files in [examples/tasks/] (https://github.com/intelsdi-x/snap-plugin-collector-processes/blob/master/examples/tasks/)):
+Create a task manifest file to use snap-plugin-collector-processes plugin (exemplary files in [examples/tasks/] (examples/tasks/)):
 ```
 {
     "version": 1,
@@ -98,9 +98,9 @@ Create a task manifest file to use snap-plugin-collector-processes plugin (exemp
             },
             "publish": [
                 {
-                    "plugin_name": "file",
+                    "plugin_name": "mock-file",
                     "config": {
-                        "file": "/tmp/published_processes"
+                        "file": "/tmp/published_processes.log"
                     }
                 }
             ],
@@ -113,7 +113,7 @@ Create a task manifest file to use snap-plugin-collector-processes plugin (exemp
 
 Create a task:
 ```
-$ $SNAP_PATH/bin/snapctl task create -t processes-file.json
+$ $SNAP_PATH/bin/snapctl task create -t examples/tasks/processes-file.json
 ```
 
 If you would like to collect all metrics exposed by this plugin, set `/intel/procfs/processes/*` as a metric to collect in task manifest.

--- a/examples/tasks/processes-file.json
+++ b/examples/tasks/processes-file.json
@@ -15,9 +15,9 @@
             },
             "publish": [
                 {
-                    "plugin_name": "file",
+                    "plugin_name": "mock-file",
                     "config": {
-                        "file": "/tmp/published_processes"
+                        "file": "/tmp/published_processes.log"
                     }
                 }
             ],

--- a/processes/processes.go
+++ b/processes/processes.go
@@ -42,7 +42,7 @@ const (
 	// fs is proc filesystem
 	fs = "procfs"
 	//version of plugin
-	version = 5
+	version = 6
 )
 
 var (

--- a/processes/procstat.go
+++ b/processes/procstat.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/intelsdi-x/snap-plugin-utilities/str"
 )
 
@@ -65,28 +66,46 @@ type Proc struct {
 // GetStats returns processes statistics
 func (psc *procStatsCollector) GetStats(procPath string) (map[string][]Proc, error) {
 	files, err := ioutil.ReadDir(procPath)
+	//log.SetOutput(os.Stderr)
 	if err != nil {
 		return nil, err
 	}
 	procs := map[string][]Proc{}
 	for _, file := range files {
+
 		// process only PID sub dirs
 		if pid, err := strconv.Atoi(file.Name()); err == nil {
 			// get proc/<pid>/stat data
 			fstat := filepath.Join(procPath, file.Name(), procStat)
 			procStat, err := ioutil.ReadFile(fstat)
 			if err != nil {
+				log.WithFields(log.Fields{
+					"pid":   pid,
+					"file":  fstat,
+					"error": err,
+				}).Errorf("Cannot get status information about the process")
 				continue
 			}
 			// get proc/<pid>/cmdline data
 			fcmd := filepath.Join(procPath, file.Name(), procCmd)
 			procCmdLine, err := ioutil.ReadFile(fcmd)
 			if err != nil {
+				log.WithFields(log.Fields{
+					"pid":   pid,
+					"file":  fcmd,
+					"error": err,
+				}).Errorf("Cannot get command line for the process")
 				continue
 			}
 			// get proc/<pid>/io data
-			procIo, err := read2Map(filepath.Join(procPath, file.Name(), procIO))
+			fio := filepath.Join(procPath, file.Name(), procIO)
+			procIo, err := read2Map(fio)
 			if err != nil {
+				log.WithFields(log.Fields{
+					"pid":   pid,
+					"file":  fio,
+					"error": err,
+				}).Errorf("Cannot get I/O statistics for the process")
 				continue
 			}
 			// get proc/<pid>/status data
@@ -98,8 +117,14 @@ func (psc *procStatsCollector) GetStats(procPath string) (map[string][]Proc, err
 				vmData = 0
 				vmCode = 0
 			} else {
-				pStatus, err = read2Map(filepath.Join(procPath, file.Name(), procStatus))
+				fstatus := filepath.Join(procPath, file.Name(), procStatus)
+				pStatus, err = read2Map(fstatus)
 				if err != nil {
+					log.WithFields(log.Fields{
+						"pid":   pid,
+						"file":  fstatus,
+						"error": err,
+					}).Errorf("Cannot get status information for the process")
 					continue
 				}
 				vmData = pStatus["VmData"] * 1024


### PR DESCRIPTION
### Summary of changes:
- added logs
- small updates in README.md
- updated Godeps & incremented the version of plugin

Before:
- there is no log about error on disappeared process (which is not returned to do not make task disabled)

After:
- in case when some file of process is unavailable (process disappeared), that will be logged (if snapd log level is set to 1 (Debug))

Exemplary logs (snapd):
```
DEBU[2016-08-29T15:54:10+02:00] time="2016-08-29T15:54:10+02:00" level=error msg="Cannot get status information about the process" error="open /proc/997/stat: no such file or directory" file="/proc/997/stat" pid=997   _module=plugin-exec io=stderr plugin=snap-plugin-collector-processes
```
